### PR TITLE
Closes #8. Adds page titles in the header. Fixes article title to the top of the column

### DIFF
--- a/css/wikibrowser.css
+++ b/css/wikibrowser.css
@@ -110,6 +110,7 @@
 }
 
 .wikibrowser-header .header-element {
+	cursor: pointer;
 	display: block;
 	float: left;
 	padding: 12px 1em 0 1em;

--- a/css/wikibrowser.css
+++ b/css/wikibrowser.css
@@ -9,15 +9,22 @@
 	right: 0;
 	bottom: 0;
 	white-space: nowrap;
+	display: flex;
+	flex-direction: row;
 }
 
 .wikibrowser-page-host {
 	position: relative;
 	width: 600px;
 	height: 100%;
-	display: inline-block; /* So that they are positioned side by side */
 	white-space: normal;
-	padding-right: 30px;
+	padding-right: 30px;	
+	/* as flex child: */
+	flex-shrink: 0;
+	flex-grow: 0;
+	/* as flex parent: */
+	display: flex;
+	flex-direction: column;
 }
 
 .wikibrowser-page-host:after {
@@ -38,11 +45,22 @@
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#a63f2828', endColorstr='#00000000',GradientType=1 ); /* IE6-9 */
 }
 
+.wikibrowser-page-header {
+	border-bottom: 1px solid #E2E3E4;
+	margin: 0 3.35em;
+	padding-top: 1em;
+}
+
+.wikibrowser-page-header h2 {
+	font-family: "Linux Libertine",Georgia,Times,serif;
+}
+
 .wikibrowser-page {
-	height: 100%;
+	flex: 1;
+	overflow-y: hidden;
 	/* Requirements for perfect-scrollbar: */
 	position: relative;
-	overflow: hidden;
+	/* overflow: hidden;*/
 }
 
 /* Header: */

--- a/css/wikibrowser.css
+++ b/css/wikibrowser.css
@@ -57,10 +57,9 @@
 
 .wikibrowser-page {
 	flex: 1;
-	overflow-y: hidden;
 	/* Requirements for perfect-scrollbar: */
+	overflow: hidden;
 	position: relative;
-	/* overflow: hidden;*/
 }
 
 /* Header: */

--- a/index.html
+++ b/index.html
@@ -21,11 +21,14 @@
 		<h1>
 			WikiBrowser
 		</h1>
-		<div class="article-icons">
-		<a href="#" target="_blank" class="header-element" alt="This is a test of the tooltip mechanism.">Test</a>
-		<a href="#" target="_blank" class="header-element" alt="Another tooltip test">Test 2</a>
+		<div class="article-icons" id="wikibrowser-article-icons">
+		
 		</div>
-		<div class="extra-icons"><a href="#" class="header-element" alt="<em>Search</em>"><span class="search-icon"></span></a></div>
+		<div class="extra-icons">
+			<a href="#" class="header-element" alt="<em>Search</em>">
+				<span class="search-icon"></span>
+			</a>
+		</div>
 
 		<!--<span class="divider"></span>-->
 		<div class="right-align">

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 		
 		</div>
 		<div class="extra-icons">
-			<a href="#" class="header-element" alt="<em>Search</em>">
+			<a href="#" class="header-element" alt="<em>Search</em>" data-associated-page="searchPage">
 				<span class="search-icon"></span>
 			</a>
 		</div>

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -191,6 +191,7 @@ function loadArticleHandler(articleName) {
 function loadArticle(articleName, previousElement) {
 	if (!isArticleLoaded(articleName)) {
 		articleTable.push(articleName);
+		createHeaderElementForArticle(articleName);
 		loadPageIntoElement(articleName, createColumnAfter(previousElement));
 	}
 }

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -5,9 +5,7 @@ $( document ).ready(function() {
   setUpSearch();
 });
 
-function createColumnAfter(previousPage) {
-	var pageId = "page" + pageIndex++;
-
+function createColumnAfter(previousPage, pageId) {
 	var tempContainer = document.createElement("div");
 	tempContainer.innerHtml = 
 '			<div class="wikibrowser-page-host wikibrowser-page-shadow" id="' + pageId + '">' +
@@ -30,14 +28,7 @@ function createColumnAfter(previousPage) {
 	// Move the search page to the very right. Do it before we calculate where to scroll.
 	resetSearch();
 
-	// Scroll to reveal the new pane
-	var newPageOffset = $("#" + pageId).offset().left;
-	var offsetDelta = $(".wikibrowser-host").scrollLeft();
-	// Subtract 600 to also show page to the left, if the view area is large enough
-	if ($(".wikibrowser-host").width() > 1200) {
-		offsetDelta -= 600;
-	}
-	$(".wikibrowser-host").animate({scrollLeft: offsetDelta + newPageOffset}, 400);
+	scrollToPageId(pageId);
 
 	return pageId;
 }
@@ -190,9 +181,10 @@ function loadArticleHandler(articleName) {
  */
 function loadArticle(articleName, previousElement) {
 	if (!isArticleLoaded(articleName)) {
-		articleTable.push(articleName);
-		createHeaderElementForArticle(articleName);
-		loadPageIntoElement(articleName, createColumnAfter(previousElement));
+		var pageId = "page" + pageIndex++;
+		articleTable[articleName] = pageId;
+		createHeaderElementForArticle(articleName, pageId);
+		loadPageIntoElement(articleName, createColumnAfter(previousElement, pageId));
 	}
 }
 

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -9,8 +9,8 @@ function addPage(previousPage) {
 
 	var tempContainer = document.createElement("div");
 	tempContainer.innerHtml = 
-'			<div class="wikibrowser-page-host wikibrowser-page-shadow">' +
-'				<div class="wikibrowser-page ps-container ps-active-y" id="' + pageId + '">'+
+'			<div class="wikibrowser-page-host wikibrowser-page-shadow" id="' + pageId + '">' +
+'				<div class="wikibrowser-page ps-container ps-active-y">'+
 '					<div class="pre-content">'+
 '						<h1 id="section_0"></h1>'+
 '					</div>'+
@@ -74,13 +74,13 @@ function loadPageIntoElement(page, element) {
 		if (typeof data.error !== 'undefined') {
 			// TODO: Make it user friendly.
 			$( "#" + element + " > .pre-content > h1" ).append( data.error.code );
-			$( "#" + element + " > .content" ).append( data.error.info );
+			$( "#" + element + " > .wikibrowser-page > .content" ).append( data.error.info );
 		}
 		else {
 			$( "#" + element + " > .pre-content > h1" ).append( data.parse.displaytitle );
-			$( "#" + element + " > .content" ).append( data.parse.text['*'] );
-			$( "#" + element + " > .content a").each(fixHyperlink);
-			$( "#" + element ).perfectScrollbar({
+			$( "#" + element + " > .wikibrowser-page > .content" ).append( data.parse.text['*'] );
+			$( "#" + element + " > .wikibrowser-page > .content a").each(fixHyperlink);
+			$( "#" + element + " > .wikibrowser-page").perfectScrollbar({
 				wheelSpeed: 3
 			});
 		}

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -1,4 +1,5 @@
 var pageIndex = 0;
+var articleTable = [];
 
 $( document ).ready(function() {
   setUpSearch();
@@ -98,7 +99,7 @@ function fixHyperlink(index, element)
 		{
 			jElement.on('click', function() {
 				var parentPageHost = jElement.closest('.wikibrowser-page-host');
-				loadPageIntoElement(address.substring(6), createColumnAfter(parentPageHost));
+				loadArticle(address.substring(6), parentPageHost);
 				return false; // prevent going to href (wikipedia)
 			});
 		}
@@ -107,7 +108,7 @@ function fixHyperlink(index, element)
 		jElement.attr('href', "http://en.wikipedia.org" + address);
 		jElement.on('click', function() {
 			var parentPageHost = jElement.closest('.wikibrowser-page-host');
-			loadPageIntoElement(address.substring(19), createColumnAfter(parentPageHost));
+			loadArticle(address.substring(19), parentPageHost);
 			return false; // prevent going to href (wikipedia)
 		})
 	}
@@ -121,7 +122,7 @@ function goToArticle(query) {
 	results = getSearchResults(query, function(results) {
 		if (verifyResults(query, results)) {
 			var bestMatch = results.query.search[0];
-			loadPageIntoElement(bestMatch.title, createColumnAfter($('#searchPageHost')));
+			loadArticle(bestMatch.title, $('#searchPageHost'));
 		}
 	});
 }
@@ -171,11 +172,27 @@ function verifyResults(query, results) {
 	}
 }
 
+/**
+ * Handler that calls loadArticle and places the new function after the search results.
+ * @param {string} articleName - title of the Wikipedia article to load
+ */
 function loadArticleHandler(articleName) {
 	// See https://stackoverflow.com/questions/9638361/how-can-i-pass-a-parameter-to-a-function-without-it-running-right-away
 	return function() {
-		loadPageIntoElement(articleName, createColumnAfter($('#searchPageHost')));
+		loadArticle(articleName, $('#searchPageHost'));
 	};
+}
+
+/**
+ * Check if article has been loaded. If not, loads the article and places it after specified article
+ * @param {string} articleName - title of the Wikipedia article to load
+ * @param {string} loadLocation - ID of element after which the article will be rendered.
+ */
+function loadArticle(articleName, previousElement) {
+	if (!isArticleLoaded(articleName)) {
+		articleTable.push(articleName);
+		loadPageIntoElement(articleName, createColumnAfter(previousElement));
+	}
 }
 
 function getSearchResults(query, callback) {
@@ -196,4 +213,8 @@ function resetSearch() {
 	$('#searchPage input').val("");
 	// Moves the #searchPageHost to the far right.
 	$(".wikibrowser-host").append($("#searchPageHost"));
+}
+
+function isArticleLoaded(articleName) {
+	return articleTable.indexOf(articleName) > -1;
 }

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -121,7 +121,6 @@ function goToArticle(query) {
 	results = getSearchResults(query, function(results) {
 		if (verifyResults(query, results)) {
 			var bestMatch = results.query.search[0];
-			loadArticle(bestMatch.title);
 			loadPageIntoElement(bestMatch.title, addPage($('#searchPageHost')));
 		}
 	});

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -10,10 +10,10 @@ function addPage(previousPage) {
 	var tempContainer = document.createElement("div");
 	tempContainer.innerHtml = 
 '			<div class="wikibrowser-page-host wikibrowser-page-shadow" id="' + pageId + '">' +
+'				<div class="wikibrowser-page-header">' +
+'					<h2></h2>' +
+'				</div>'+
 '				<div class="wikibrowser-page ps-container ps-active-y">'+
-'					<div class="pre-content">'+
-'						<h1 id="section_0"></h1>'+
-'					</div>'+
 '					<div id="content" class="content"></div>'+
 '				</div>'+
 '			</div>';
@@ -73,14 +73,14 @@ function loadPageIntoElement(page, element) {
 	.done(function(data) {
 		if (typeof data.error !== 'undefined') {
 			// TODO: Make it user friendly.
-			$( "#" + element + " > .pre-content > h1" ).append( data.error.code );
-			$( "#" + element + " > .wikibrowser-page > .content" ).append( data.error.info );
+			$( "#" + element + " > .wikibrowser-page-header > h2" ).append( data.error.code );
+			$( "#" + element + " .wikibrowser-page > .content" ).append( data.error.info );
 		}
 		else {
-			$( "#" + element + " > .pre-content > h1" ).append( data.parse.displaytitle );
-			$( "#" + element + " > .wikibrowser-page > .content" ).append( data.parse.text['*'] );
-			$( "#" + element + " > .wikibrowser-page > .content a").each(fixHyperlink);
-			$( "#" + element + " > .wikibrowser-page").perfectScrollbar({
+			$( "#" + element + " > .wikibrowser-page-header > h2" ).append( data.parse.displaytitle );
+			$( "#" + element + " .wikibrowser-page > .content" ).append( data.parse.text['*'] );
+			$( "#" + element + " .wikibrowser-page > .content a").each(fixHyperlink);
+			$( "#" + element + " .wikibrowser-page").perfectScrollbar({
 				wheelSpeed: 3
 			});
 		}

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -4,7 +4,7 @@ $( document ).ready(function() {
   setUpSearch();
 });
 
-function addPage(previousPage) {
+function createColumnAfter(previousPage) {
 	var pageId = "page" + pageIndex++;
 
 	var tempContainer = document.createElement("div");
@@ -98,7 +98,7 @@ function fixHyperlink(index, element)
 		{
 			jElement.on('click', function() {
 				var parentPageHost = jElement.closest('.wikibrowser-page-host');
-				loadPageIntoElement(address.substring(6), addPage(parentPageHost));
+				loadPageIntoElement(address.substring(6), createColumnAfter(parentPageHost));
 				return false; // prevent going to href (wikipedia)
 			});
 		}
@@ -107,7 +107,7 @@ function fixHyperlink(index, element)
 		jElement.attr('href', "http://en.wikipedia.org" + address);
 		jElement.on('click', function() {
 			var parentPageHost = jElement.closest('.wikibrowser-page-host');
-			loadPageIntoElement(address.substring(19), addPage(parentPageHost));
+			loadPageIntoElement(address.substring(19), createColumnAfter(parentPageHost));
 			return false; // prevent going to href (wikipedia)
 		})
 	}
@@ -121,7 +121,7 @@ function goToArticle(query) {
 	results = getSearchResults(query, function(results) {
 		if (verifyResults(query, results)) {
 			var bestMatch = results.query.search[0];
-			loadPageIntoElement(bestMatch.title, addPage($('#searchPageHost')));
+			loadPageIntoElement(bestMatch.title, createColumnAfter($('#searchPageHost')));
 		}
 	});
 }
@@ -174,7 +174,7 @@ function verifyResults(query, results) {
 function loadArticle(articleName) {
 	// See https://stackoverflow.com/questions/9638361/how-can-i-pass-a-parameter-to-a-function-without-it-running-right-away
 	return function() {
-		loadPageIntoElement(articleName, addPage($('#searchPageHost')));
+		loadPageIntoElement(articleName, createColumnAfter($('#searchPageHost')));
 	};
 }
 

--- a/scripts/retriever.js
+++ b/scripts/retriever.js
@@ -136,7 +136,7 @@ function searchArticle(query) {
 				var resultItem = document.createElement("li");
 				var displayTitle = results.query.search[index].titlesnippet !== "" ? results.query.search[index].titlesnippet : results.query.search[index].title;
 				$(resultItem).html(displayTitle);
-				$(resultItem).on('click', loadArticle(results.query.search[index].title));
+				$(resultItem).on('click', loadArticleHandler(results.query.search[index].title));
 				$('.wikibrowser-search-results').append(resultItem);
 			}
 			/* If not visible, reveal the results */
@@ -171,7 +171,7 @@ function verifyResults(query, results) {
 	}
 }
 
-function loadArticle(articleName) {
+function loadArticleHandler(articleName) {
 	// See https://stackoverflow.com/questions/9638361/how-can-i-pass-a-parameter-to-a-function-without-it-running-right-away
 	return function() {
 		loadPageIntoElement(articleName, createColumnAfter($('#searchPageHost')));

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -3,6 +3,7 @@ var movingTooltipPointer;
 var movingTooltipFinalContent;
 var movingTooltipTempContent;
 var header;
+var articleIconsHost;
 var hoveredElements = 0;
 
 $( document ).ready(function() {
@@ -17,11 +18,15 @@ $( document ).ready(function() {
 function setUpTooltips() {
 	var elements = $(".wikibrowser-header .header-element");
 	$.each(elements, function(index, element) {
-		$(element).hover(mouseEnter, mouseLeave);
+		setUpTooltip($(element));
 	});
 }
 
-function mouseEnter() {
+function setUpTooltip(jElement) {
+	jElement.hover(headerElementMouseEnter, headerElementMouseLeave);
+}
+
+function headerElementMouseEnter() {
 	hoveredElements++;
 
 	var jElement = $(this);
@@ -109,7 +114,7 @@ function mouseEnter() {
 	);
 }
 
-function mouseLeave() {
+function headerElementMouseLeave() {
 	hoveredElements--;
 	if (hoveredElements == 0) {
 		movingTooltip.stop().animate(

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -4,6 +4,7 @@ var movingTooltipFinalContent;
 var movingTooltipTempContent;
 var header;
 var articleIconsHost;
+var wikiBrowserHost;
 var hoveredElements = 0;
 
 $( document ).ready(function() {
@@ -13,23 +14,23 @@ $( document ).ready(function() {
 	movingTooltipPointer = $('#tooltip-pointer');
 	header = $('.wikibrowser-header'); // TODO: make it an ID
 	articleIconsHost = $('#wikibrowser-article-icons');
-	setUpTooltips();
+	wikiBrowserHost = $('.wikibrowser-host'); // TODO: make it an ID
+	setUpInitialMouseEvents();
 });
 
-function setUpTooltips() {
+function setUpInitialMouseEvents() {
 	var elements = $(".wikibrowser-header .header-element");
 	$.each(elements, function(index, element) {
-		setUpTooltip($(element));
+		setUpMouseEvents($(element));
 	});
 }
 
-function setUpTooltip(jElement) {
+function setUpMouseEvents(jElement) {
 	jElement.hover(headerElementMouseEnter, headerElementMouseLeave);
+	jElement.click(headerElementClick);
 }
 
-function createHeaderElementForArticle(articleName) {
-	// '_' -> ' ' for nice tooltip and simpler regex
-	articleName = articleName.replace(/_/g, " ");
+function createHeaderElementForArticle(articleName, pageID) {
 	// Remove &redirect=no
 	if (articleName.indexOf('&') > -1) {
 		articleName = articleName.substring(0, articleName.indexOf('&'));
@@ -38,19 +39,23 @@ function createHeaderElementForArticle(articleName) {
 	if (articleName.indexOf('#') > -1) {
 		articleName = articleName.substring(0, articleName.indexOf('#'));
 	}	
-	console.log("Hello and welcome: " + articleName);
+	// '_' -> ' ' for nice tooltip and simpler regex
+	articleName = articleName.replace(/_/g, " ");	
+
+	// Capture first letters of words
+	var acronym = articleName.match(/\b([a-zA-Z])/g).join(''); 
+	// Limit length of the acronym
+	acronym = acronym.substring(0, 6);
+
+	// Create the header element
 	var $element = $("<a>", {
 		target: "_blank",
 		class: "header-element",
 		alt: articleName
 	})
-	// Capture first letters of words
-	var acronym = articleName.match(/\b([a-zA-Z])/g).join(''); 
-	// Limit length of the acronym
-	acronym = acronym.substring(0, 6);
-	console.log("You shall be named: " + acronym);
 	$element.html(acronym);
-	setUpTooltip($element);
+	$element.data("associated-page", pageID);
+	setUpMouseEvents($element);
 	articleIconsHost.append($element);
 }
 
@@ -173,4 +178,23 @@ function headerElementMouseLeave() {
  			}
  		);		
 	}
+}
+
+function headerElementClick() {
+	var jElement = $(this);
+	var pageId = jElement.data("associated-page");
+	if (typeof pageId !== 'undefined')
+	{
+		scrollToPageId(pageId);
+	}
+}
+
+function scrollToPageId(pageId) {
+	var newPageOffset = $("#" + pageId).offset().left;
+	var offsetDelta = wikiBrowserHost.scrollLeft();
+	// Subtract 600 to also show page to the left, if the view area is large enough
+	if (wikiBrowserHost.width() > 1200) {
+		offsetDelta -= 600;
+	}
+	wikiBrowserHost.animate({scrollLeft: offsetDelta + newPageOffset}, 400);
 }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -12,6 +12,7 @@ $( document ).ready(function() {
 	movingTooltipTempContent = $('#hidden-tooltip span');
 	movingTooltipPointer = $('#tooltip-pointer');
 	header = $('.wikibrowser-header'); // TODO: make it an ID
+	articleIconsHost = $('#wikibrowser-article-icons');
 	setUpTooltips();
 });
 
@@ -24,6 +25,33 @@ function setUpTooltips() {
 
 function setUpTooltip(jElement) {
 	jElement.hover(headerElementMouseEnter, headerElementMouseLeave);
+}
+
+function createHeaderElementForArticle(articleName) {
+	// '_' -> ' ' for nice tooltip and simpler regex
+	articleName = articleName.replace(/_/g, " ");
+	// Remove &redirect=no
+	if (articleName.indexOf('&') > -1) {
+		articleName = articleName.substring(0, articleName.indexOf('&'));
+	}
+	// Remove #anchor
+	if (articleName.indexOf('#') > -1) {
+		articleName = articleName.substring(0, articleName.indexOf('#'));
+	}	
+	console.log("Hello and welcome: " + articleName);
+	var $element = $("<a>", {
+		target: "_blank",
+		class: "header-element",
+		alt: articleName
+	})
+	// Capture first letters of words
+	var acronym = articleName.match(/\b([a-zA-Z])/g).join(''); 
+	// Limit length of the acronym
+	acronym = acronym.substring(0, 6);
+	console.log("You shall be named: " + acronym);
+	$element.html(acronym);
+	setUpTooltip($element);
+	articleIconsHost.append($element);
 }
 
 function headerElementMouseEnter() {


### PR DESCRIPTION
Uses display:flex which makes the site incompatible with IE 9 and lower.
The article's title is now fixed to the top of the column and always visible.
Header contains links to page titles that allow scrolling to these articles.